### PR TITLE
Use date_i18n() to localize event date and time display

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -11,13 +11,13 @@ class Event extends Model {
     public function get_date(): string {
         $dateTime = Helpers::format_datetime( $this->get_field( 'time' ) );
 
-        return $dateTime->format( get_option( 'date_format' ) );
+        return date_i18n( get_option( 'date_format' ), $dateTime->getTimestamp() );
     }
 
     public function get_time(): string {
         $dateTime = Helpers::format_datetime( $this->get_field( 'time' ) );
 
-        return $dateTime->format( get_option( 'time_format' ) );
+        return date_i18n( get_option( 'time_format' ), $dateTime->getTimestamp() );
     }
 
     public function get_checkout_url(): string {


### PR DESCRIPTION
This small change ensures that event date and time formatting respects the current WordPress locale, such as when switching languages using Polylang or other multilingual plugins.

It replaces `$dateTime->format(...)` with `date_i18n(...)`, preserving the selected format but enabling translation of month/day names.

Fixes issue where month names would remain in English even when the site is viewed in another language.

Thanks for the great plugin!
